### PR TITLE
Simpler error reporting

### DIFF
--- a/bin/mapbox-tile-copy.js
+++ b/bin/mapbox-tile-copy.js
@@ -61,7 +61,7 @@ fs.exists(srcfile, function(exists) {
 
   mapboxTileCopy(srcfile, dsturi, options, function(err){
     if (err) {
-      console.error(err.toString());
+      console.error(err);
       process.exit(err.code === 'EINVALID' ? 3 : 1);
     }
 

--- a/lib/invalid.js
+++ b/lib/invalid.js
@@ -3,16 +3,9 @@ var path = require('path');
 var util = require('util');
 
 module.exports = function invalid(err) {
-  var msg = typeof err === 'string' ?
-    util.format.apply(this, arguments) : err.message;
+  if (typeof err === 'string')
+    err = new Error(util.format.apply(this, arguments));
 
-  msg = msg
-    .replace(new RegExp(path.join(os.tmpdir(),'[0-9a-z]+-'), 'g'), '');
-
-  var error = new Error(msg);
-  error.code = 'EINVALID';
-
-  if (err.stack) error.stack = err.stack;
-  
-  return error;
+  err.code = 'EINVALID';
+  return err;
 };

--- a/test/executable.test.js
+++ b/test/executable.test.js
@@ -74,7 +74,7 @@ test('invalid source file', function(t) {
   var cmd = [ copy, fixture, dst ].join(' ');
   exec(cmd, function(err, stdout, stderr) {
     t.ok(err, 'expected error');
-    t.equal(stderr, 'Error: Unknown filetype.\n', 'expected message');
+    t.ok(/Error: Unknown filetype\./.test(stderr), 'expected message');
     t.equal(err.code, 3, 'exit code 3');
     t.end();
   });


### PR DESCRIPTION
Don't adjust invalid errors more than setting `err.code = 'EINVALID'`

cc @willwhite 
