### PR TITLE
Close tilelive source

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: node_js
 node_js:
 - '0.10'
+sudo: false
 before_install:
-- sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-- sudo apt-get update -q
-- sudo apt-get install -y libstdc++6
+- if [[ $(uname -s) == 'Linux' ]]; then wget https://launchpad.net/~ubuntu-toolchain-r/+archive/ubuntu/test/+files/libstdc%2B%2B6_4.8.1-2ubuntu1~12.04_amd64.deb && dpkg -x libstdc++6_4.8.1-2ubuntu1~12.04_amd64.deb ./ && export LD_PRELOAD=$(pwd)/usr/lib/x86_64-linux-gnu/libstdc++.so.6; fi
 env:
   global:
   - secure: rFbJCcDbGQtC+PGL2NU/hGkEuzDdWL7AukuhqYBE2VcfCNsohc9EiIhLVrW5VTggLX/Eo8AEiUSIEGlto9RWkuF5Rh2SrA70gSMdm6gdEjHncJCR6yxXqJs5R6evC33k1xtfD7yQ/Ove+FXjyxfw4g6wYH40wGAZhO+fwGJDVdw=

--- a/lib/copy.js
+++ b/lib/copy.js
@@ -73,31 +73,31 @@ function tilelivecopy(srcUri, s3url, options, callback) {
   var protocol = url.parse(srcUri).protocol;
   if (protocol === 'mbtiles:') scheme = 'list';
   if (protocol === 'omnivore:') scheme = 'pyramid';
+  options.type = scheme;
 
-  tilelive.info(srcUri, function(err, info) {
+  tilelive.load(srcUri, function(err, src) {
     if (err) {
       err.code = 'EINVALID';
       return callback(err);
     }
 
-    options.minzoom = options.minzoom || info.minzoom;
-    options.maxzoom = options.maxzoom || info.maxzoom;
-    options.bounds = options.bounds || info.bounds;
-    options.type = scheme;
+    src.getInfo(function(err, info) {
+      if (err) {
+        err.code = 'EINVALID';
+        return callback(err);
+      }
 
-    if (scheme === 'list') {
-      return tilelive.load(srcUri, function(err, src) {
-        if (err) {
-          err.code = 'EINVALID';
-          return callback(err);
-        }
+      options.minzoom = options.minzoom || info.minzoom;
+      options.maxzoom = options.maxzoom || info.maxzoom;
+      options.bounds = options.bounds || info.bounds;
+      if (scheme === 'list') options.listStream = src.createZXYStream();
 
-        options.listStream = src.createZXYStream();
-        tilelive.copy(src, s3url, options, callback);
+      tilelive.copy(src, s3url, options, function(err) {
+        if (err) return callback(err);
+        if (typeof src.close === 'function') return src.close(callback);
+        callback();
       });
-    }
-
-    tilelive.copy(srcUri, s3url, options, callback);
+    });
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "mapbox-studio-default-fonts": "https://mapbox-npm.s3.amazonaws.com/package/mapbox-studio-default-fonts-0.0.4-4afb5235f457bd1c1a5a70fce6c2aa83bf7a851e.tgz",
     "mapbox-studio-pro-fonts": "https://mapbox-npm.s3.amazonaws.com/package/mapbox-studio-pro-fonts-1.0.0-9870a90b713f307b9391829602f4d5857e419615.tgz",
     "mapnik": "^3.1.1",
-    "mbtiles": "^0.7.8",
+    "mbtiles": "^0.7.9",
     "minimist": "~0.2.0",
     "progress-stream": "^0.5.0",
     "s3urls": "^1.3.0",


### PR DESCRIPTION
Closes tilelive sources before firing the callback passed to `mapboxTileCopy`.

Passes tests once https://github.com/mapbox/node-mbtiles/pull/54 lands.

cc @springmeyer 