### PR TITLE
Close both src and dst

### DIFF
--- a/lib/copy.js
+++ b/lib/copy.js
@@ -5,6 +5,7 @@ var util = require('util');
 var S3 = require('tilelive-s3');
 var tilelive = require('tilelive');
 var progress = require('progress-stream');
+var queue = require('queue-async');
 
 function serialtiles(srcUri, s3urlTemplate, options, callback) {
   if (!callback) {
@@ -75,33 +76,43 @@ function tilelivecopy(srcUri, s3url, options, callback) {
   if (protocol === 'omnivore:') scheme = 'pyramid';
   options.type = scheme;
 
-  tilelive.load(srcUri, function(err, src) {
-    if (err) {
-      err.code = 'EINVALID';
-      return callback(err);
-    }
+  queue()
+    .defer(tilelive.load, srcUri)
+    .defer(tilelive.load, s3url)
+    .await(function(err, src, dst) {
+      function close(err) {
+        var srcClose = src && typeof src.close === 'function' ?
+          src.close.bind(src) : function(cb) { cb(); };
+        var dstClose = dst && typeof dst.close === 'function' ?
+          dst.close.bind(dst) : function(cb) { cb(); };
 
-    function close(err) {
-      if (typeof src.close !== 'function') return callback(err);
-      src.close(function(closeErr) {
-        callback(err || closeErr);
-      });
-    }
+        queue()
+          .defer(srcClose)
+          .defer(dstClose)
+          .await(function(closeErr) {
+            callback(err || closeErr);
+          });
+      }
 
-    src.getInfo(function(err, info) {
       if (err) {
         err.code = 'EINVALID';
         return close(err);
       }
 
-      options.minzoom = options.minzoom || info.minzoom;
-      options.maxzoom = options.maxzoom || info.maxzoom;
-      options.bounds = options.bounds || info.bounds;
-      if (scheme === 'list') options.listStream = src.createZXYStream();
+      src.getInfo(function(err, info) {
+        if (err) {
+          err.code = 'EINVALID';
+          return close(err);
+        }
 
-      tilelive.copy(src, s3url, options, close);
+        options.minzoom = options.minzoom || info.minzoom;
+        options.maxzoom = options.maxzoom || info.maxzoom;
+        options.bounds = options.bounds || info.bounds;
+        if (scheme === 'list') options.listStream = src.createZXYStream();
+
+        tilelive.copy(src, dst, options, close);
+      });
     });
-  });
 }
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "mbtiles": "^0.7.9",
     "minimist": "~0.2.0",
     "progress-stream": "^0.5.0",
+    "queue-async": "^1.0.7",
     "s3urls": "^1.3.0",
     "tilejson": "^0.10.0",
     "tilelive": "5.6.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "s3urls": "^1.3.0",
     "tilejson": "^0.10.0",
     "tilelive": "5.6.1",
-    "tilelive-omnivore": "^1.1.2",
+    "tilelive-omnivore": "^1.1.4",
     "tilelive-s3": "^1.3.0",
     "tilelive-vector": "3.2.2"
   },


### PR DESCRIPTION
While I'm working on mapbox-tile-copy endgame -- let's close both the source and destination tilelive modules.
