### PR TITLE
Stat

### DIFF
--- a/bin/help
+++ b/bin/help
@@ -1,0 +1,11 @@
+Usage:
+  mapbox-tile-copy <src> <dst> [--options]
+
+Example:
+  mapbox-tile-copy orig.mbtiles s3://bucket/prefix/{z}/{x}/{y}
+
+Options:
+  --parts=[number]
+  --part=[number]
+  --retry=[number]     Retry get/put operations on failure
+  --progressinterval=[number of seconds]   If not included, shows progress by default

--- a/bin/help
+++ b/bin/help
@@ -1,11 +1,17 @@
 Usage:
   mapbox-tile-copy <src> <dst> [--options]
 
+Description:
+  mapbox-tile-copy takes a source that can be an MBTiles file,
+  serialtiles, vector datasource, or others, generates or extracts
+  tiles from it, and pushes the result to an S3 bucket.
+
 Example:
   mapbox-tile-copy orig.mbtiles s3://bucket/prefix/{z}/{x}/{y}
 
 Options:
   --parts=[number]
   --part=[number]
+  --stats=[filename]
   --retry=[number]     Retry get/put operations on failure
   --progressinterval=[number of seconds]   If not included, shows progress by default

--- a/bin/mapbox-tile-copy.js
+++ b/bin/mapbox-tile-copy.js
@@ -24,17 +24,7 @@ var s3urls = require('s3urls');
 var argv = require('minimist')(process.argv.slice(2));
 
 if (!argv._[0]) {
-  console.log('Usage:');
-  console.log('  mapbox-tile-copy <src> <dst> [--options]');
-  console.log('');
-  console.log('Example:');
-  console.log('  mapbox-tile-copy orig.mbtiles s3://bucket/prefix/{z}/{x}/{y}');
-  console.log('');
-  console.log('Options:');
-  console.log('  --parts=[number]');
-  console.log('  --part=[number]');
-  console.log('  --retry=[number]     Retry get/put operations on failure');
-  console.log('  --progressinterval=[number of seconds]   If not included, shows progress by default');
+  process.stdout.write(fs.readFileSync(__dirname + '/help', 'utf8'));
   process.exit(1);
 }
 

--- a/index.js
+++ b/index.js
@@ -41,8 +41,8 @@ module.exports = function(filepath, s3url, options, callback) {
     }
   });
 
-  function copied(err) {
-    if (!err) return callback();
+  function copied(err, stats) {
+    if (!err) return callback(err, stats);
     var fatal = { SQLITE_CORRUPT: true, EINVALIDTILE: true };
     if (fatal[err.code]) err.code = 'EINVALID';
     return callback(err);

--- a/lib/serialtilescopy.js
+++ b/lib/serialtilescopy.js
@@ -1,5 +1,6 @@
 var fs = require('fs');
 var util = require('util');
+var TileStatStream = require('tile-stat-stream');
 var tilelive = require('tilelive');
 var zlib = require('zlib');
 var url = require('url');
@@ -12,6 +13,8 @@ function serialtiles(srcUri, s3urlTemplate, options, callback) {
     callback = options;
     options = {};
   }
+
+  var statStream = new TileStatStream();
 
   var max_tilesize = options.limits && options.limits.max_tilesize ?
     options.limits.max_tilesize : 500 * 1024;
@@ -64,12 +67,23 @@ function serialtiles(srcUri, s3urlTemplate, options, callback) {
 
     if (options.progress) prog.on('progress', function(p) { options.progress(stats, p); });
 
-    source
-      .pipe(gunzip)
-      .pipe(deserialize)
-      .pipe(validate)
-      .pipe(prog)
-      .pipe(s3);
+    if (options.stats) {
+      source
+        .pipe(gunzip)
+        .pipe(deserialize)
+        .pipe(validate)
+        .pipe(statStream)
+        .pipe(prog)
+        .pipe(s3);
+    } else {
+      source
+        .pipe(gunzip)
+        .pipe(deserialize)
+        .pipe(validate)
+        .pipe(prog)
+        .pipe(s3);
+
+    }
   }
 
   function done(err) {
@@ -77,7 +91,11 @@ function serialtiles(srcUri, s3urlTemplate, options, callback) {
     once = true;
 
     if (err) source.unpipe();
-    callback(err);
+    if (options.stats) {
+      callback(err, statStream.getStatistics());
+    } else {
+      callback(err);
+    }
   }
 }
 

--- a/lib/tilelivecopy.js
+++ b/lib/tilelivecopy.js
@@ -1,5 +1,6 @@
 var url = require('url');
 var tilelive = require('tilelive');
+var TileStatStream = require('tile-stat-stream');
 var queue = require('queue-async');
 
 function tilelivecopy(srcUri, s3url, options, callback) {
@@ -8,6 +9,8 @@ function tilelivecopy(srcUri, s3url, options, callback) {
   if (protocol === 'mbtiles:') scheme = 'list';
   if (protocol === 'omnivore:') scheme = 'pyramid';
   options.type = scheme;
+
+  var stats = new TileStatStream();
 
   queue()
     .defer(tilelive.load, srcUri)
@@ -23,7 +26,11 @@ function tilelivecopy(srcUri, s3url, options, callback) {
           .defer(srcClose)
           .defer(dstClose)
           .await(function(closeErr) {
-            callback(err || closeErr);
+            if (options.stats) {
+              callback(err || closeErr, stats.getStatistics());
+            } else {
+              callback(err || closeErr);
+            }
           });
       }
 
@@ -42,6 +49,10 @@ function tilelivecopy(srcUri, s3url, options, callback) {
         options.maxzoom = options.maxzoom || info.maxzoom;
         options.bounds = options.bounds || info.bounds;
         if (scheme === 'list') options.listStream = src.createZXYStream();
+
+        if (options.stats) {
+          options.transform = stats;
+        }
 
         tilelive.copy(src, dst, options, close);
       });

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "progress-stream": "^0.5.0",
     "queue-async": "^1.0.7",
     "s3urls": "^1.3.0",
+    "tile-stat-stream": "^1.0.0",
     "tilejson": "^0.10.0",
     "tilelive": "^5.7.0",
     "tilelive-omnivore": "~1.2.0",

--- a/test/copy.serialtiles.test.js
+++ b/test/copy.serialtiles.test.js
@@ -88,6 +88,21 @@ test('serialtiles-copy: parallel processing', function(t) {
   });
 });
 
+test('serialtiles-copy: stats', function(t) {
+  var uri = [
+    'serialtiles:',
+    path.resolve(__dirname, 'fixtures', 'valid.serialtiles.gzip.vector.gz')
+  ].join('//');
+
+  var urlTemplate = util.format(s3url, 'test.valid-parallel', '0');
+
+  copy(uri, urlTemplate, { stats: true, job: { num: 0, total: 10 } }, function(err, stats) {
+    t.ifError(err, 'no error');
+    t.equal(stats.world_merc.count, 245);
+    t.end();
+  });
+});
+
 test('serialtiles-copy: tiles too big', function(t) {
   var uri = [
     'serialtiles:',

--- a/test/copy.tilelive.test.js
+++ b/test/copy.tilelive.test.js
@@ -117,11 +117,10 @@ test('copy omnivore stats', function(t) {
   sinon.spy(tilelive, 'copy');
 
   onlineTiles = dst;
-  var stats = new TileStatStream();
-  tileliveCopy(src, dst, { maxzoom: 5, transform: stats }, function(err) {
+  tileliveCopy(src, dst, { maxzoom: 5, stats: true }, function(err, stats) {
     t.ifError(err, 'copied');
-    t.ok(stats.getStatistics(), 'has stats');
-    t.equal(stats.getStatistics().valid.geometryTypes.Polygon, 215, 'Counts polygons');
+    t.ok(stats, 'has stats');
+    t.equal(stats.valid.geometryTypes.Polygon, 215, 'Counts polygons');
     tilelive.copy.restore();
     t.end();
   });

--- a/test/executable.test.js
+++ b/test/executable.test.js
@@ -89,6 +89,7 @@ test('stats flag', function(t) {
   var cmd = [ copy, fixture, '--stats=' + tmpfile, dst ].join(' ');
   exec(cmd, function(err, stdout, stderr) {
     t.ifError(err, 'no error');
+    t.pass(tmpfile);
     var stats = JSON.parse(fs.readFileSync(tmpfile));
     t.ok(stats);
     t.equal(stats.valid.geometryTypes.Polygon, 21344, 'Counts polygons');


### PR DESCRIPTION
Add and test integration with tile-stat-stream.

This adds a --stat=filename flag to the bin that will generate
stats and dump them as JSON to a local file.

/cc @rclark for the review