### PR TITLE
Passthrough timeout arg

### DIFF
--- a/bin/mapbox-tile-copy.js
+++ b/bin/mapbox-tile-copy.js
@@ -60,6 +60,7 @@ if (isNumeric(argv.part) && isNumeric(argv.parts)) options.job = {
 };
 
 if (isNumeric(argv.retry)) options.retry = parseInt(argv.retry, 10);
+if (isNumeric(argv.timeout)) options.timeout = parseInt(argv.timeout, 10);
 
 if (!dsturi || !s3urls.valid(dsturi)) {
   console.error('You must provide a valid S3 url');


### PR DESCRIPTION
Allows the executable to pass `--timeout` arg through to tilelive.copy.