### PR TITLE
Handle invalid feature error

### DIFF
--- a/lib/tilelivecopy.js
+++ b/lib/tilelivecopy.js
@@ -17,10 +17,10 @@ function tilelivecopy(srcUri, s3url, options, callback) {
     .defer(tilelive.load, s3url)
     .await(function(err, src, dst) {
       function done(err) {
-        if ((err.message).indexOf('Failed to parse geojson feature') != -1 ) {
+        if (err && (err.message).indexOf('Failed to parse geojson feature') != -1 ) {
           err.code = 'EINVALID';
         }
-        
+
         if (options.stats) {
           callback(err, stats.getStatistics());
         } else {

--- a/lib/tilelivecopy.js
+++ b/lib/tilelivecopy.js
@@ -17,6 +17,10 @@ function tilelivecopy(srcUri, s3url, options, callback) {
     .defer(tilelive.load, s3url)
     .await(function(err, src, dst) {
       function done(err) {
+        if ((err.message).indexOf('Failed to parse geojson feature') != -1 ) {
+          err.code = 'EINVALID';
+        }
+        
         if (options.stats) {
           callback(err, stats.getStatistics());
         } else {


### PR DESCRIPTION
Handle invalid features instead of crashing (explicitly mark as `EINVALID`).

cc @rclark 