### PR TITLE
Upgrade tilelive-s3. ACL defaults to private and use SSE.

### DIFF
--- a/lib/serialtilescopy.js
+++ b/lib/serialtilescopy.js
@@ -34,7 +34,8 @@ function serialtiles(srcUri, s3urlTemplate, options, callback) {
   };
 
   new S3({
-    data: { tiles: [ s3urlTemplate ] }
+    data: { tiles: [ s3urlTemplate ] },
+    sse: 'AES256'
   }, function(err, dst) {
     if (err) return callback(err);
     copy(dst);

--- a/lib/tilelivecopy.js
+++ b/lib/tilelivecopy.js
@@ -49,6 +49,7 @@ function tilelivecopy(srcUri, s3url, options, callback) {
           options.transform = stats;
         }
 
+        dst.sse = 'AES256';
         tilelive.copy(src, dst, options, done);
       });
     });

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "tilejson": "^0.10.0",
     "tilelive": "~5.11.0",
     "tilelive-omnivore": "~2.0.0",
-    "tilelive-s3": "~3.1.0",
+    "tilelive-s3": "~5.0.0",
     "tilelive-vector": "~3.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Upgrade to tilelive-s3 5.0.0, which sets S3 ACL private by default and adds support for setting S3 server-side encryption settings. 