### PR TITLE
tilelive-s3 with endpoint configuration via environment variable

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "tilejson": "^0.10.0",
     "tilelive": "~5.11.0",
     "tilelive-omnivore": "~2.1.0",
-    "tilelive-s3": "https://github.com/mapbox/tilelive-s3/tarball/environment-endpoint",
+    "tilelive-s3": "^6.2.0",
     "tilelive-vector": "~3.5.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "tilejson": "^0.10.0",
     "tilelive": "~5.11.0",
     "tilelive-omnivore": "~2.1.0",
-    "tilelive-s3": "~6.1.0",
+    "tilelive-s3": "https://github.com/mapbox/tilelive-s3/tarball/environment-endpoint",
     "tilelive-vector": "~3.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Upgrade to tilelive-s3 version that supports endpoint configuration using an environment variable.

/cc @rclark @dnomadb 