### PR TITLE
updated util.print to console.log

### DIFF
--- a/bin/mapbox-tile-copy.js
+++ b/bin/mapbox-tile-copy.js
@@ -104,7 +104,7 @@ function getProgress(statistics, prog) {
 
 function report(final) {
   if (!stats || !p) return;
-  util.print(util.format('%s%s tiles @ %s/s, %s% complete [%ss]%s',
+  console.log(util.format('%s%s tiles @ %s/s, %s% complete [%ss]%s',
     interval > 0 ? '' : '\r\033[K',
     p.transferred,
     Math.round(p.speed),


### PR DESCRIPTION
Use console.log instead of util.print as it is deprecated. https://nodejs.org/api/util.html#util_util_print