### PR TITLE
[WIP] Serialtile & Mbtile validation

### DIFF
--- a/lib/serialtilescopy.js
+++ b/lib/serialtilescopy.js
@@ -6,7 +6,11 @@ var zlib = require('zlib');
 var url = require('url');
 var progress = require('progress-stream');
 var S3 = require('tilelive-s3');
-var ValidationStream = require('mapbox-upload-validate/lib/validators/serialtiles').ValidationStream;
+
+var tiletype = require('tiletype');
+var mapnik = require('mapnik');
+var stream = require('stream');
+// var ValidationStream = require('mapbox-upload-validate/lib/validators/serialtiles').ValidationStream;
 
 function serialtiles(srcUri, s3urlTemplate, options, callback) {
   if (!callback) {
@@ -60,7 +64,9 @@ function serialtiles(srcUri, s3urlTemplate, options, callback) {
         done(err);
       });
 
-    var validate = new ValidationStream({ validateVectorTiles: true })
+    var validate = new ValidationStream({ 
+      validateVectorTiles: true, 
+      numTiles: max_tilesize })
       .on('error', function(err) {
         err.code = 'EINVALID';
         done(err);
@@ -98,6 +104,82 @@ function serialtiles(srcUri, s3urlTemplate, options, callback) {
       callback(err);
     }
   }
+}
+
+var ValidationStream = function(options) {
+  var validationStream = new stream.Transform({ objectMode: true });
+  validationStream.tiles = 0;
+  validationStream.max = options.numTiles || Infinity;
+
+  validationStream._transform = function(tile, enc, callback) {
+    if (!tile.buffer) return callback();
+
+    if (validationStream.tiles >= validationStream.max) {
+      validationStream.push(tile);
+      validationStream.tiles++;
+      return callback();
+    }
+
+    var format = tiletype.type(tile.buffer);
+    if (!format) return callback(invalid('Invalid tiletype'));
+
+    // if (!validLength(tile, options.sizeLimit))
+    //   return callback(invalid('Tile exceeds maximum size of ' + Math.round(options.sizeLimit / 1024) + 'k at z' + tile.z + '. Reduce the detail of data at this zoom level or omit it by adjusting your minzoom.'));
+
+    // if (!options.validateVectorTiles || format !== 'pbf') {
+    //   validationStream.push(tile);
+    //   validationStream.tiles++;
+    //   return callback();
+    // }
+
+    validateVectorTile(tile, function(err) {
+      if (err) return callback(err);
+      validationStream.push(tile);
+      validationStream.tiles++;
+      return callback();
+    });
+  };
+
+  return validationStream;
+};
+
+function validateVectorTile(tile, callback) {
+  var vtile = new mapnik.VectorTile(tile.z, tile.x, tile.y);
+
+  vtile.setData(tile.buffer, function(err) {
+    
+    // Right now we are just sending a generic error response.
+    // We can return more info from Node Mapnik if we need
+    // but tests currently check for DeserializationError.
+    if (err) {
+      err.name = 'DeserializationError';
+      err.message = 'Invalid data';
+      return callback(err);
+    }
+
+    // copying response from mapbox-upload-validate
+    if (vtile.empty()) {
+      var error = {
+        code: 'EINVALID',
+        message: 'Tile is empty'
+      };
+      return callback(error);
+    }
+
+    return callback();
+  });
+
+  // OR WE CAN DO THIS
+
+  // var info = mapnik.VectorTile.info(tile.buffer);
+  // if (inf.errors) {
+  //   var error = {
+  //     name: 'DeserializationError',
+  //     message: 'Invalid Data'      
+  //   };
+  //   return callback(error);
+  // }
+
 }
 
 module.exports = serialtiles;

--- a/lib/serialtilescopy.js
+++ b/lib/serialtilescopy.js
@@ -144,41 +144,42 @@ var ValidationStream = function(options) {
 };
 
 function validateVectorTile(tile, callback) {
-  var vtile = new mapnik.VectorTile(tile.z, tile.x, tile.y);
+  // var vtile = new mapnik.VectorTile(tile.z, tile.x, tile.y);
 
-  vtile.setData(tile.buffer, function(err) {
+  // vtile.setData(tile.buffer, function(err) {
     
-    // Right now we are just sending a generic error response.
-    // We can return more info from Node Mapnik if we need
-    // but tests currently check for DeserializationError.
-    if (err) {
-      err.name = 'DeserializationError';
-      err.message = 'Invalid data';
-      return callback(err);
-    }
+  //   // Right now we are just sending a generic error response.
+  //   // We can return more info from Node Mapnik if we need
+  //   // but tests currently check for DeserializationError.
+  //   if (err) {
+  //     err.name = 'DeserializationError';
+  //     err.message = 'Invalid data';
+  //     return callback(err);
+  //   }
 
-    // copying response from mapbox-upload-validate
-    if (vtile.empty()) {
-      var error = {
-        code: 'EINVALID',
-        message: 'Tile is empty'
-      };
-      return callback(error);
-    }
+  //   // copying response from mapbox-upload-validate
+  //   if (vtile.empty()) {
+  //     var error = {
+  //       code: 'EINVALID',
+  //       message: 'Tile is empty'
+  //     };
+  //     return callback(error);
+  //   }
 
-    return callback();
-  });
+  //   return callback();
+  // });
 
   // OR WE CAN DO THIS
 
-  // var info = mapnik.VectorTile.info(tile.buffer);
-  // if (inf.errors) {
-  //   var error = {
-  //     name: 'DeserializationError',
-  //     message: 'Invalid Data'      
-  //   };
-  //   return callback(error);
-  // }
+  var info = mapnik.VectorTile.info(tile.buffer);
+  if (info.errors) {
+    var error = {
+      name: 'DeserializationError',
+      message: 'Invalid data'      
+    };
+    return callback(error);
+  }
+  return callback();
 
 }
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "mapbox-file-sniff": "~0.4.0",
     "mapbox-studio-default-fonts": "https://mapbox-npm.s3.amazonaws.com/package/mapbox-studio-default-fonts-0.0.4-4afb5235f457bd1c1a5a70fce6c2aa83bf7a851e.tgz",
     "mapbox-studio-pro-fonts": "https://mapbox-npm.s3.amazonaws.com/package/mapbox-studio-pro-fonts-1.0.0-9870a90b713f307b9391829602f4d5857e419615.tgz",
-    "mapnik": "~3.4.6",
+    "mapnik": "~3.5.0",
     "mbtiles": "^0.8.0",
     "minimist": "~0.2.0",
     "progress-stream": "^0.5.0",
@@ -28,10 +28,10 @@
     "s3urls": "^1.3.0",
     "tile-stat-stream": "^1.0.1",
     "tilejson": "^0.10.0",
-    "tilelive": "~5.11.0",
-    "tilelive-omnivore": "~2.1.0",
+    "tilelive": "~5.12.0",
+    "tilelive-omnivore": "~2.2.0",
     "tilelive-s3": "^6.2.0",
-    "tilelive-vector": "~3.5.0",
+    "tilelive-vector": "~3.9.0",
     "tiletype": "^0.3.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "mapbox-file-sniff": "~0.4.0",
     "mapbox-studio-default-fonts": "https://mapbox-npm.s3.amazonaws.com/package/mapbox-studio-default-fonts-0.0.4-4afb5235f457bd1c1a5a70fce6c2aa83bf7a851e.tgz",
     "mapbox-studio-pro-fonts": "https://mapbox-npm.s3.amazonaws.com/package/mapbox-studio-pro-fonts-1.0.0-9870a90b713f307b9391829602f4d5857e419615.tgz",
-    "mapbox-upload-validate": "~3.2.0",
     "mapnik": "~3.4.6",
     "mbtiles": "^0.8.0",
     "minimist": "~0.2.0",
@@ -32,7 +31,8 @@
     "tilelive": "~5.11.0",
     "tilelive-omnivore": "~2.1.0",
     "tilelive-s3": "^6.2.0",
-    "tilelive-vector": "~3.5.0"
+    "tilelive-vector": "~3.5.0",
+    "tiletype": "^0.3.0"
   },
   "devDependencies": {
     "aws-sdk": "^2.0.25",


### PR DESCRIPTION
- [x] update mapnik version to `~3.5.0` and subsequent downstream deps
- [x]  remove `mapbox-upload-validate` as a dependency
- [x]  include serialtile validation into `lib/serialtilecopy.js` by running through `mapnik.VectorTile.info()` and checking for errors
- [ ] introduce mbtiles validation from `mapbox-upload-validate` that checks through *every* tile [instead of just the first](https://github.com/mapbox/mapbox-upload-validate/blob/df7b1de3d0e4f49abe905e2c3655e08821862c96/lib/validators/mbtiles.js#L35-L51)