### PR TITLE
Ensure tiles are upgraded

### DIFF
--- a/lib/migration-stream.js
+++ b/lib/migration-stream.js
@@ -7,7 +7,7 @@ module.exports.migrate = migrate;
 
 function migrate(tile, callback) {
   var vtile = new mapnik.VectorTile(tile.z, tile.x, tile.y);
-  vtile.setData(tile.buffer, function(err) {
+  vtile.setData(tile.buffer, {upgrade:true}, function(err) {
     if (err) {
         err.code = 'EINVALID';
         return callback(err);

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "mapbox-file-sniff": "~0.4.0",
     "mapbox-studio-default-fonts": "https://mapbox-npm.s3.amazonaws.com/package/mapbox-studio-default-fonts-0.0.4-4afb5235f457bd1c1a5a70fce6c2aa83bf7a851e.tgz",
     "mapbox-studio-pro-fonts": "https://mapbox-npm.s3.amazonaws.com/package/mapbox-studio-pro-fonts-1.0.0-9870a90b713f307b9391829602f4d5857e419615.tgz",
-    "mapnik": "~3.5.5",
+    "mapnik": "~3.5.9",
     "mbtiles": "^0.8.0",
     "minimist": "~0.2.0",
     "progress-stream": "^0.5.0",

--- a/test/copy.serialtiles.test.js
+++ b/test/copy.serialtiles.test.js
@@ -34,7 +34,7 @@ test('serialtiles-copy: gzipped vector tiles', function(t) {
       t.ifError(err, 'found expected file on s3');
       t.equal(res.statusCode, 200, 'expected status code');
       t.equal(res.headers['content-type'], 'application/x-protobuf', 'expected content-type');
-      t.equal(res.headers['content-length'], '36634', 'expected content-length');
+      t.equal(res.headers['content-length'], '36649', 'expected content-length');
       t.equal(res.headers['content-encoding'], 'gzip', 'expected content-encoding');
       var info = mapnik.VectorTile.info(res.body);
       t.equal(info.layers[0].version, 2, 'vector tile is version 2');
@@ -61,7 +61,7 @@ test('serialtiles-copy: retry', function(t) {
       t.ifError(err, 'found expected file on s3');
       t.equal(res.statusCode, 200, 'expected status code');
       t.equal(res.headers['content-type'], 'application/x-protobuf', 'expected content-type');
-      t.equal(res.headers['content-length'], '36634', 'expected content-length');
+      t.equal(res.headers['content-length'], '36649', 'expected content-length');
       t.equal(res.headers['content-encoding'], 'gzip', 'expected content-encoding');
       var info = mapnik.VectorTile.info(res.body);
       t.equal(info.layers[0].version, 2, 'vector tile is version 2');


### PR DESCRIPTION
Upcoming node-mapnik v3.5.9 no longer upgrades by default in `setData` and `addData` so we need to supply this option.

 - refs https://github.com/mapnik/node-mapnik/pull/626