### PR TITLE
Sanitize migration errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.6.1
+
+- Only [log the error message](https://github.com/mapbox/mapbox-tile-copy/pull/70) from `bin/mapbox-tile-copy.js` instead of the full stack trace
+
 ## 4.6.0
 
 - Bundle support: Ability to handle multiple files for a single tileset

--- a/bin/mapbox-tile-copy.js
+++ b/bin/mapbox-tile-copy.js
@@ -82,7 +82,7 @@ fs.exists(srcfile0, function(exists) {
   if (options.bundle === true) { srcfile = 'omnivore://' + srcfile };
   mapboxTileCopy(srcfile, dsturi, options, function(err, stats) {
     if (err) {
-      console.error(err.stack);
+      console.error(err.message);
       process.exit(err.code === 'EINVALID' ? 3 : 1);
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mapbox-tile-copy",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "description": "From geodata files to tiles on S3",
   "main": "index.js",
   "scripts": {

--- a/test/executable.test.js
+++ b/test/executable.test.js
@@ -77,7 +77,8 @@ test('invalid source file', function(t) {
   var cmd = [ copy, fixture, dst ].join(' ');
   exec(cmd, function(err, stdout, stderr) {
     t.ok(err, 'expected error');
-    t.ok(/Error: Unknown filetype/.test(stderr), 'expected message');
+    console.log(stderr);
+    t.ok(/Unknown filetype/.test(stderr), 'expected message');
     t.equal(err.code, 3, 'exit code 3');
     t.end();
   });

--- a/test/executable.test.js
+++ b/test/executable.test.js
@@ -83,6 +83,18 @@ test('invalid source file', function(t) {
   });
 });
 
+test('invalid mbtile, expected error from migration stream', function(t) {
+  var fixture = path.resolve(__dirname, 'fixtures', 'invalid.tiles.mbtiles');
+  var dst = dsturi('invalid.tiles.mbtiles');
+  var cmd = [ copy, fixture, dst ].join(' ');
+  exec(cmd, function(err, stdout, stderr) {
+    t.ok(err, 'expected error');
+    t.ok(/Vector Tile Feature has no geometry/.test(stderr), 'expected message');
+    t.equal(err.code, 3, 'exit code 3');
+    t.end();
+  });
+});
+
 test('stats flag', function(t) {
   var dst = dsturi('valid.geojson');
   var fixture = path.resolve(__dirname, 'fixtures', 'valid.geojson');

--- a/test/executable.test.js
+++ b/test/executable.test.js
@@ -77,7 +77,6 @@ test('invalid source file', function(t) {
   var cmd = [ copy, fixture, dst ].join(' ');
   exec(cmd, function(err, stdout, stderr) {
     t.ok(err, 'expected error');
-    console.log(stderr);
     t.ok(/Unknown filetype/.test(stderr), 'expected message');
     t.equal(err.code, 3, 'exit code 3');
     t.end();


### PR DESCRIPTION
Right now we are sending the full stack trace for errors with the `bin` command, which is a bit verbose. This just sends back the error message.

Might be worth adding a `--verbose` flag so we can add stack traces back in?

cc @rclark @GretaCB 