### PR TITLE
Can specify regions

### DIFF
--- a/cloudformation/travis-mapbox-tile-copy-test.template
+++ b/cloudformation/travis-mapbox-tile-copy-test.template
@@ -13,7 +13,8 @@
                             "Statement": [
                                 {
                                     "Resource": [
-                                        "arn:aws:s3:::tilestream-tilesets-development/*"
+                                        "arn:aws:s3:::tilestream-tilesets-development/*",
+                                        "arn:aws:s3:::mapbox-eu-central-1/test/mapbox-tile-copy/*"
                                     ],
                                     "Action": [
                                         "s3:GetObject",
@@ -30,6 +31,20 @@
                                         "s3:ListBucket"
                                     ],
                                     "Effect": "Allow"
+                                },
+                                {
+                                    "Resource": [
+                                        "arn:aws:s3:::mapbox-eu-central-1"
+                                    ],
+                                    "Action": [
+                                        "s3:ListBucket"
+                                    ],
+                                    "Effect": "Allow",
+                                    "Condition": {
+                                        "StringLike": {
+                                            "s3:prefix": "test/mapbox-tile-copy/*"
+                                        }
+                                    }
                                 }
                             ]
                         }

--- a/index.js
+++ b/index.js
@@ -31,7 +31,9 @@ if (process.env.MapboxTileCopyFonts)
 
 module.exports = function(filepath, s3url, options, callback) {
   // Make sure the s3url is of type s3://bucket/key
+  var query = url.parse(s3url).query;
   s3url = s3urls.convert(s3url, 's3');
+  if (query) s3url += '?' + query;
 
   if (options.bundle === true) {
     tilelivecopy(filepath, s3url, options, copied);

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "tilejson": "^1.0.1",
     "tilelive": "~5.12.2",
     "tilelive-omnivore": "2.5.1",
-    "tilelive-s3": "^6.2.0",
+    "tilelive-s3": "https://github.com/mapbox/tilelive-s3/tarball/regions",
     "tilelive-vector": "~3.9.1",
     "tiletype": "^0.3.0"
   },

--- a/test/copy.tilelive.test.js
+++ b/test/copy.tilelive.test.js
@@ -331,7 +331,7 @@ test('copy coordinates exceed spherical mercator', function(t) {
 });
 
 test('successfully copy a bigtiff', function(t) {
-  var fixture = path.resolve(__dirname, 'fixtures', 'valid.bigtiff.tif'); 
+  var fixture = path.resolve(__dirname, 'fixtures', 'valid.bigtiff.tif');
   var src = 'omnivore://' + fixture;
   var dst = dsturi('valid.bigtiff');
   sinon.spy(tilelive, 'copy');
@@ -342,6 +342,28 @@ test('successfully copy a bigtiff', function(t) {
       t.ifError(err, 'counted tiles');
       t.equal(count, 121, 'rendered all tiles');
       t.equal(tilelive.copy.getCall(0).args[2].type, 'pyramid', 'uses pyramid scheme for tifs');
+      tilelive.copy.restore();
+      t.end();
+    });
+  });
+});
+
+test('copy omnivore to Frankfurt', function(t) {
+  var fixture = path.resolve(__dirname, 'fixtures', 'valid.geojson');
+  var src = 'omnivore://' + fixture;
+  var dst = [
+    's3://mapbox-eu-central-1/test/mapbox-tile-copy',
+    runid,
+    'valid.geojson/{z}/{x}/{y}?region=eu-central-1'
+  ].join('/');
+  sinon.spy(tilelive, 'copy');
+
+  tileliveCopy(src, dst, { maxzoom: 5 }, function(err) {
+    t.ifError(err, 'copied');
+    tileCount(dst, function(err, count) {
+      t.ifError(err, 'counted tiles');
+      t.equal(count, 27, 'expected number of tiles');
+      t.equal(tilelive.copy.getCall(0).args[2].type, 'pyramid', 'uses pyramid scheme for geojson');
       tilelive.copy.restore();
       t.end();
     });


### PR DESCRIPTION
Allows specification of a `?region=` querystring to setup the AWS S3 client in tilelive-s3 appropriately for other buckets.