### PR TITLE
tilelive-s3@6.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "tilejson": "^1.0.1",
     "tilelive": "~5.12.2",
     "tilelive-omnivore": "2.5.1",
-    "tilelive-s3": "6.4.0",
+    "tilelive-s3": "6.4.1",
     "tilelive-vector": "~3.9.1",
     "tiletype": "^0.3.0"
   },


### PR DESCRIPTION
Fixes an issue when region info is passed to tilelive-s3 via pre-parsed uri object.