### PR TITLE
Zero-indexed parts, for sure

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -37,14 +37,24 @@ Copy tiles from one S3 location to another via tilejson describing the source:
 $ mapbox-tile-copy ~/data/online-data.tilejson s3://my-bucket/folder/tilejson/{z}/{x}/{y}
 ```
 
+Render image tiles from vector tiles, using custom fonts from a location on your computer:
+```sh
+$ MapboxTileCopyFonts=/path/to/font/dir mapbox-tile-copy ~/style.tm2z s3://my-bucket/pngs/{z}/{x}/{y}
+```
+
 Perform a part of a copy operation. [Useful for parallel processing a large file](https://github.com/mapbox/tilelive.js#parallel-read-streams):
 ```sh
 $ mapbox-tile-copy ~/data/my-tiles.mbtiles s3://my-bucket/parallel/{z}/{x}/{y} --part 2 --parts 12
 ```
 
-Render image tiles from vector tiles, using custom fonts from a location on your computer:
+The `--part` operation is explicitly _zero-indexed_ because this gives tilelive's stream processors a predictable way to segment tiles per part. For example, the following will distribute all tiles among a single part. So all tiles will be rendered by this single part:
 ```sh
-$ MapboxTileCopyFonts=/path/to/font/dir mapbox-tile-copy ~/style.tm2z s3://my-bucket/pngs/{z}/{x}/{y}
+$ mapbox-tile-copy ~/data/my-tiles.mbtiles s3://my-bucket/parallel/{z}/{x}/{y} --part 0 --parts 1
+```
+
+The following example will distribute tiles to the second part out of 5 total parts:
+```sh
+$ mapbox-tile-copy ~/data/my-tiles.mbtiles s3://my-bucket/parallel/{z}/{x}/{y} --part 1 --parts 4
 ```
 
 ## Supported file types

--- a/test/executable.test.js
+++ b/test/executable.test.js
@@ -269,7 +269,7 @@ test('part zero', function(t) {
   });
 });
 
-test('single part zero', function(t) {
+test('single part', function(t) {
   var dst = dsturi('valid.single.zero');
   var cmd = [ copy, fixture, dst, '--part', '0', '--parts', '1' ].join(' ');
   exec(cmd, function(err, stdout, stderr) {
@@ -277,25 +277,7 @@ test('single part zero', function(t) {
     t.equal(stdout.length, 77, 'expected stdout.length');
     tileCount(dst, function(err, count) {
       t.ifError(err, 'counted tiles');
-      console.log(stdout);
-      console.log(count);
-      t.ok(count < 4, 'did not render all tiles');
-      t.end();
-    });
-  });
-});
-
-test('single part one', function(t) {
-  var dst = dsturi('valid.single.one');
-  var cmd = [ copy, fixture, dst, '--part', '1', '--parts', '1' ].join(' ');
-  exec(cmd, function(err, stdout, stderr) {
-    t.ifError(err, 'copied');
-    t.equal(stdout.length, 77, 'expected stdout.length');
-    tileCount(dst, function(err, count) {
-      console.log(stdout);
-      console.log(count);
-      t.ifError(err, 'counted tiles');
-      t.ok(count < 4, 'did not render all tiles');
+      t.ok(count == 4, 'rendered all tiles');
       t.end();
     });
   });

--- a/test/executable.test.js
+++ b/test/executable.test.js
@@ -269,6 +269,35 @@ test('part zero', function(t) {
   });
 });
 
+test('single part zero', function(t) {
+  var dst = dsturi('valid.single.zero');
+  var cmd = [ copy, fixture, dst, '--part', '0', '--parts', '1' ].join(' ');
+  exec(cmd, function(err, stdout, stderr) {
+    t.ifError(err, 'copied');
+    t.equal(stdout.length, 77, 'expected stdout.length');
+    tileCount(dst, function(err, count) {
+      t.ifError(err, 'counted tiles');
+      console.log(count);
+      t.ok(count < 4, 'did not render all tiles');
+      t.end();
+    });
+  });
+});
+
+test('single part one', function(t) {
+  var dst = dsturi('valid.single.one');
+  var cmd = [ copy, fixture, dst, '--part', '1', '--parts', '1' ].join(' ');
+  exec(cmd, function(err, stdout, stderr) {
+    t.ifError(err, 'copied');
+    t.equal(stdout.length, 77, 'expected stdout.length');
+    tileCount(dst, function(err, count) {
+      t.ifError(err, 'counted tiles');
+      t.ok(count < 4, 'did not render all tiles');
+      t.end();
+    });
+  });
+});
+
 test('retry', function(t) {
   var dst = dsturi('valid.retry');
   var cmd = [ copy, fixture, dst, '--retry', '5' ].join(' ');

--- a/test/executable.test.js
+++ b/test/executable.test.js
@@ -277,6 +277,7 @@ test('single part zero', function(t) {
     t.equal(stdout.length, 77, 'expected stdout.length');
     tileCount(dst, function(err, count) {
       t.ifError(err, 'counted tiles');
+      console.log(stdout);
       console.log(count);
       t.ok(count < 4, 'did not render all tiles');
       t.end();
@@ -291,6 +292,8 @@ test('single part one', function(t) {
     t.ifError(err, 'copied');
     t.equal(stdout.length, 77, 'expected stdout.length');
     tileCount(dst, function(err, count) {
+      console.log(stdout);
+      console.log(count);
       t.ifError(err, 'counted tiles');
       t.ok(count < 4, 'did not render all tiles');
       t.end();


### PR DESCRIPTION
Add test to ensure a zero-indexed single-part copy job includes all tiles and update docs to include clarity around `--parts` operation.

cc @rclark @mapsam 
Fixes #56 