### PR TITLE
fail with missing template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 5.1.1
 
 - Add error handling for missing `{z}/{x}/{y}` template in the destination URL.
+- test to make sure that zero-indexing is happening correctly (all tiles copied to a single part)
 
 ## 5.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.1.1
+
+- Add error handling for missing `{z}/{x}/{y}` template in the destination URL.
+
 ## 5.1.0
 
 - Upgrade mapnik-omnivore#8.1.0, tilelive-omnivore@3.1.0, mapbox-file-sniff@0.5.2, mbtiles@0.9.0

--- a/index.js
+++ b/index.js
@@ -35,6 +35,10 @@ module.exports = function(filepath, s3url, options, callback) {
   s3url = s3urls.convert(s3url, 's3');
   if (query) s3url += '?' + query;
 
+  if (s3url.indexOf('{z}') == -1 ||
+      s3url.indexOf('{x}') == -1 ||
+      s3url.indexOf('{y}') == -1) return callback(new Error('Destination URL does not include a {z}/{x}/{y} template.'));
+
   if (options.bundle === true) {
     tilelivecopy(filepath, s3url, options, copied);
   } else {

--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,8 @@ You'll be writing to S3, and so you'll need to make sure that your shell environ
 $ mapbox-tile-copy <file> <s3 url template>
 ```
 
+Your s3 url template must include a `{z}/{x}/{y}` scheme for writing and distributing tiles. File extensions are not required.
+
 #### Examples:
 
 Copy tiles from an mbtiles file to a folder in `my-bucket`:

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -98,3 +98,15 @@ test('null mbtiles', function(t) {
     });
   });
 });
+
+test('fails with missing {z}/{x}/{y} template', function(t) {
+  var fixture = path.resolve(__dirname, 'fixtures', 'valid.mbtiles');
+  var dst = dsturi('valid.mbtiles');
+  var dst = dst.slice(0, dst.indexOf('{z}'));
+  console.log(dst);
+  copy(fixture, dst, {}, function(err) {
+    t.ok(err);
+    t.equal(err.message, 'Destination URL does not include a {z}/{x}/{y} template.');
+    t.end();
+  });
+});


### PR DESCRIPTION
Adds a check for `{z}/{x}/{y}` template in the destination string. I added three separate checks for `{z}`, `{x}`, and `{y}` in case someone uses a different style template, like `{z}-{x}-{y}`.

refs: #85 

cc @GretaCB @rclark @who8mycakes 