### PR TITLE
include --timeout option in help

### DIFF
--- a/bin/help
+++ b/bin/help
@@ -15,3 +15,4 @@ Options:
   --stats=[filename]
   --retry=[number]     Retry get/put operations on failure
   --progressinterval=[number of seconds]   If not included, shows progress by default
+  --timeout=[numbel]   Timeout for copy operation, default=60000


### PR DESCRIPTION
Having this in the --help page would have saved me a bit of time working out how to fix the "Copy operation timed out" message.