### PR TITLE
update tilelive-s3

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ var MBTiles = require('mbtiles');
 var Omnivore = require('@mapbox/tilelive-omnivore');
 var TileJSON = require('tilejson');
 var Mapbox = require('./lib/tilelive-mapbox');
-var S3 = require('tilelive-s3');
+var S3 = require('@mapbox/tilelive-s3');
 var path = require('path');
 
 // Note: tilelive-vector is needed for `tm2z` protocol (https://github.com/mapbox/tilelive-vector/issues/124)

--- a/lib/serialtilescopy.js
+++ b/lib/serialtilescopy.js
@@ -6,7 +6,7 @@ var zlib = require('zlib');
 var url = require('url');
 var progress = require('progress-stream');
 var MigrationStream = require('./migration-stream');
-var S3 = require('tilelive-s3');
+var S3 = require('@mapbox/tilelive-s3');
 
 function serialtiles(srcUri, s3urlTemplate, options, callback) {
   if (!callback) {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@mapbox/tilelive-omnivore": "~3.1.0",
     "@mapbox/tilelive-vector": "~3.9.1",
+    "@mapbox/tilelive-s3": "https://github.com/mapbox/tilelive-s3/tarball/update-aws-sdk",
     "mapbox-file-sniff": "~0.5.2",
     "mapbox-studio-default-fonts": "https://mapbox-npm.s3.amazonaws.com/package/mapbox-studio-default-fonts-0.0.4-4afb5235f457bd1c1a5a70fce6c2aa83bf7a851e.tgz",
     "mapbox-studio-pro-fonts": "https://mapbox-npm.s3.amazonaws.com/package/mapbox-studio-pro-fonts-1.0.0-9870a90b713f307b9391829602f4d5857e419615.tgz",
@@ -32,7 +33,6 @@
     "tile-stat-stream": "^1.0.1",
     "tilejson": "^1.0.1",
     "tilelive": "~5.12.2",
-    "tilelive-s3": "https://github.com/mapbox/tilelive-s3/tarball/update-aws-sdk",
     "tiletype": "^0.3.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@mapbox/tilelive-omnivore": "~3.1.0",
     "@mapbox/tilelive-vector": "~3.9.1",
-    "@mapbox/tilelive-s3": "https://github.com/mapbox/tilelive-s3/tarball/update-aws-sdk",
+    "@mapbox/tilelive-s3": "6.5.1",
     "mapbox-file-sniff": "~0.5.2",
     "mapbox-studio-default-fonts": "https://mapbox-npm.s3.amazonaws.com/package/mapbox-studio-default-fonts-0.0.4-4afb5235f457bd1c1a5a70fce6c2aa83bf7a851e.tgz",
     "mapbox-studio-pro-fonts": "https://mapbox-npm.s3.amazonaws.com/package/mapbox-studio-pro-fonts-1.0.0-9870a90b713f307b9391829602f4d5857e419615.tgz",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "tile-stat-stream": "^1.0.1",
     "tilejson": "^1.0.1",
     "tilelive": "~5.12.2",
-    "tilelive-s3": "6.4.1",
+    "tilelive-s3": "https://github.com/mapbox/tilelive-s3/tarball/update-aws-sdk",
     "tiletype": "^0.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Updating tilelive-s3 to the namespace module and allowing for more recent versions of the aws-sdk.

cc @springmeyer