### PR TITLE
remove stats option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 7.0.0
+
+- Remove tile-stat-stream and stats as an option [#105](https://github.com/mapbox/mapbox-tile-copy/issues/105)
+
 ## 6.4.0
 
-- Add V1 tile tracker. 
+- Add V1 tile tracker.
 
 ## N/A
 

--- a/bin/mapbox-tile-copy.js
+++ b/bin/mapbox-tile-copy.js
@@ -36,8 +36,6 @@ var options = {};
 
 options.progress = getProgress;
 
-options.stats = !!argv.stats;
-
 ['minzoom','maxzoom'].forEach(function(zoomopt) {
   if (!!argv[zoomopt]) {
     if (isNumeric(argv[zoomopt])) {
@@ -80,17 +78,13 @@ fs.exists(srcfile0, function(exists) {
   }
 
   if (options.bundle === true) { srcfile = 'omnivore://' + srcfile };
-  mapboxTileCopy(srcfile, dsturi, options, function(err, stats) {
+  mapboxTileCopy(srcfile, dsturi, options, function(err) {
     if (err) {
       console.error(err.message);
       process.exit(err.code === 'EINVALID' ? 3 : 1);
     }
 
-    if (argv.stats) {
-      fs.writeFile(argv.stats, JSON.stringify(stats), done);
-    } else {
-      done();
-    }
+    done();
 
     function done() {
       if (interval !== 0) report(true);
@@ -99,16 +93,14 @@ fs.exists(srcfile0, function(exists) {
   });
 });
 
-var stats, p;
-
-function getProgress(statistics, prog) {
-  stats = statistics;
+var p;
+function getProgress(prog) {
   p = prog;
   if (interval < 0) report();
 }
 
 function report(final) {
-  if (!stats || !p) return;
+  if (!p) return;
   console.log(util.format('%s%s tiles @ %s/s, %s% complete [%ss]%s',
     interval > 0 ? '' : '\r\033[K',
     p.transferred,

--- a/lib/serialtilescopy.js
+++ b/lib/serialtilescopy.js
@@ -1,6 +1,5 @@
 var fs = require('fs');
 var util = require('util');
-var TileStatStream = require('tile-stat-stream');
 var tilelive = require('@mapbox/tilelive');
 var zlib = require('zlib');
 var url = require('url');
@@ -65,22 +64,12 @@ function serialtiles(srcUri, s3urlTemplate, options, callback) {
 
     if (options.progress) prog.on('progress', function(p) { options.progress(stats, p); });
 
-    if (options.stats) {
-      source
-        .pipe(gunzip)
-        .pipe(deserialize)
-        .pipe(migrate)
-        .pipe(statStream)
-        .pipe(prog)
-        .pipe(s3);
-    } else {
-      source
-        .pipe(gunzip)
-        .pipe(deserialize)
-        .pipe(migrate)
-        .pipe(prog)
-        .pipe(s3);
-    }
+    source
+      .pipe(gunzip)
+      .pipe(deserialize)
+      .pipe(migrate)
+      .pipe(prog)
+      .pipe(s3);
   }
 
   function done(err) {
@@ -88,11 +77,7 @@ function serialtiles(srcUri, s3urlTemplate, options, callback) {
     once = true;
 
     if (err) source.unpipe();
-    if (options.stats) {
-      callback(err, statStream.getStatistics());
-    } else {
-      callback(err);
-    }
+    callback(err);
   }
 }
 

--- a/lib/tilelivecopy.js
+++ b/lib/tilelivecopy.js
@@ -1,7 +1,6 @@
 var url = require('url');
 var tilelive = require('@mapbox/tilelive');
 var tileliveOmivore = require('@mapbox/tilelive-omnivore');
-var TileStatStream = require('tile-stat-stream');
 var queue = require('queue-async');
 var combiner = require('stream-combiner');
 var MigrationStream = require('./migration-stream');
@@ -12,8 +11,6 @@ function tilelivecopy(srcUri, s3url, options, callback) {
   if (protocol === 'mbtiles:') scheme = 'list';
   if (protocol === 'omnivore:') scheme = 'scanline';
   options.type = scheme;
-
-  var stats = new TileStatStream();
 
   queue()
     .defer(tilelive.load, srcUri)
@@ -31,11 +28,7 @@ function tilelivecopy(srcUri, s3url, options, callback) {
           err.message = 'Coordinates beyond web mercator range. Please check projection and lat/lon values.'
         }
 
-        if (options.stats) {
-          callback(err, stats.getStatistics());
-        } else {
-          callback(err);
-        }
+        callback(err);
       }
 
       if (err) {
@@ -57,7 +50,6 @@ function tilelivecopy(srcUri, s3url, options, callback) {
 
         var transforms = [];
 
-        if (options.stats) transforms.push(stats);
         if (protocol === 'mbtiles:' || protocol === 'tilejson:') transforms.push(MigrationStream());
         if (transforms.length > 0) options.transform = combiner(transforms);
 

--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
     "minimist": "~0.2.0",
     "progress-stream": "^0.5.0",
     "queue-async": "^1.0.7",
-    "stream-combiner": "^0.2.2",
-    "tile-stat-stream": "^1.0.1"
+    "stream-combiner": "^0.2.2"
   },
   "devDependencies": {
     "aws-sdk": "^2.0.25",

--- a/test/copy.serialtiles.test.js
+++ b/test/copy.serialtiles.test.js
@@ -128,21 +128,6 @@ test('serialtiles-copy: parallel processing', function(t) {
   });
 });
 
-test('serialtiles-copy: stats', function(t) {
-  var uri = [
-    'serialtiles:',
-    path.resolve(__dirname, 'fixtures', 'valid.serialtiles.gzip.vector.gz')
-  ].join('//');
-
-  var urlTemplate = util.format(s3url, 'test.valid-parallel', '0');
-
-  copy(uri, urlTemplate, { stats: true, job: { num: 0, total: 10 } }, function(err, stats) {
-    t.ifError(err, 'no error');
-    t.equal(stats.world_merc.count, 223);
-    t.end();
-  });
-});
-
 test('serialtiles-copy: tiles too big', function(t) {
   var uri = [
     'serialtiles:',

--- a/test/copy.tilelive.test.js
+++ b/test/copy.tilelive.test.js
@@ -11,7 +11,6 @@ var os = require('os');
 var fs = require('fs');
 var mtc = require('..'); // just to get protocols registered
 var sinon = require('sinon');
-var TileStatStream = require('tile-stat-stream');
 
 process.env.MapboxAPIMaps = 'https://api.tiles.mapbox.com';
 
@@ -94,7 +93,7 @@ test('copy mbtiles without v1 tile logging', function(t) {
 });
 
 test('copy mbtiles with v1 tile logging', function(t) {
-  process.env.LOG_V1_TILES = true; 
+  process.env.LOG_V1_TILES = true;
   var fixture = path.resolve(__dirname, 'fixtures', 'valid.mbtiles');
   var src = 'mbtiles://' + fixture;
   var dst = dsturi('valid.mbtiles');
@@ -110,8 +109,8 @@ test('copy mbtiles with v1 tile logging', function(t) {
       tileVersion(dst, 0, 0, 0, function(err, version) {
         var path = './v1-stats.json';
         t.equal(fs.existsSync(path), true);
-        process.env.LOG_V1_TILES = false; 
-        fs.unlinkSync(path); 
+        process.env.LOG_V1_TILES = false;
+        fs.unlinkSync(path);
         t.end();
       });
     });
@@ -181,21 +180,6 @@ test('copy omnivore', function(t) {
       tilelive.copy.restore();
       t.end();
     });
-  });
-});
-
-test('copy omnivore stats', function(t) {
-  var fixture = path.resolve(__dirname, 'fixtures', 'valid.geojson');
-  var src = 'omnivore://' + fixture;
-  var dst = dsturi('valid.geojson');
-  sinon.spy(tilelive, 'copy');
-
-  tileliveCopy(src, dst, { maxzoom: 5, stats: true }, function(err, stats) {
-    t.ifError(err, 'copied');
-    t.ok(stats, 'has stats');
-    t.equal(stats.valid.geometryTypes.Polygon, 452, 'Counts polygons');
-    tilelive.copy.restore();
-    t.end();
   });
 });
 
@@ -313,7 +297,7 @@ test('passes through invalid tile in mbtiles', function(t) {
   var fixture = path.resolve(__dirname, 'fixtures', 'invalid.tile-with-no-geometry.mbtiles');
   var src = 'mbtiles://' + fixture;
   var dst = dsturi('invalid.tile-with-no-geometry.mbtiles');
-  tileliveCopy(src, dst, {}, function(err, stats) {
+  tileliveCopy(src, dst, {}, function(err) {
     t.ifError(err, 'passes through invalid.tile-with-no-geometry.mbtiles');
     tileCount(dst, function(err, count) {
       t.ifError(err, 'counted tiles');

--- a/test/executable.test.js
+++ b/test/executable.test.js
@@ -97,21 +97,6 @@ test('handles mbtile with missing geometry', function(t) {
   });
 });
 
-test('stats flag', function(t) {
-  var dst = dsturi('valid.geojson');
-  var fixture = path.resolve(__dirname, 'fixtures', 'valid.geojson');
-  var tmpfile = path.join(os.tmpdir(), crypto.randomBytes(8).toString('hex'));
-  var cmd = [ copy, fixture, '--stats=' + tmpfile, dst ].join(' ');
-  exec(cmd, function(err, stdout, stderr) {
-    t.ifError(err, 'no error');
-    t.pass(tmpfile);
-    var stats = JSON.parse(fs.readFileSync(tmpfile));
-    t.ok(stats);
-    t.equal(Math.abs(15800 - stats.valid.geometryTypes.Polygon) < 200, true, 'Counts polygons (+/-15800)');
-    t.end();
-  });
-});
-
 test('minzoom flag valid', function(t) {
   var dst = dsturi('valid.mini.geojson');
   var fixture = path.resolve(__dirname, 'fixtures', 'valid.mini.geojson');


### PR DESCRIPTION
This removes tile-stat-stream, which is no longer maintained, and removes statistics as an option from mapbox-tile-copy. This will result in a new major release, 7.x.

Refs: #105 

TODO

- [ ] update module warnings (if possible)

cc @springmeyer @GretaCB @millzpaugh @rclark 