### PR TITLE
catch tile size error from tilelive-bridge

### DIFF
--- a/lib/tilelivecopy.js
+++ b/lib/tilelivecopy.js
@@ -37,6 +37,11 @@ function tilelivecopy(srcUri, s3url, options, callback) {
           err.message = 'Unable to reproject data. Please reproject to Web Mercator (EPSG:3857) and try again.'
         }
 
+        if (err && err.message.indexOf('Tile >= max allowed size') != -1 && process.env.BRIDGE_MAX_VTILE_BYTES_COMPRESSED) {
+          err.code = 'EINVALID';
+          err.message = `Tile size exceeds limit. At least one vector tile is larger than ${process.env.BRIDGE_MAX_VTILE_BYTES_COMPRESSED/1000000}MB.`;
+        }
+
         if (options.stats) {
           callback(err, stats.getStatistics());
         } else {

--- a/lib/tilelivecopy.js
+++ b/lib/tilelivecopy.js
@@ -37,6 +37,7 @@ function tilelivecopy(srcUri, s3url, options, callback) {
           err.message = 'Unable to reproject data. Please reproject to Web Mercator (EPSG:3857) and try again.'
         }
 
+        // tile size limits from tilelive-bridge
         if (err && err.message.indexOf('Tile >= max allowed size') != -1 && process.env.BRIDGE_MAX_VTILE_BYTES_COMPRESSED) {
           err.code = 'EINVALID';
           err.message = `Tile size exceeds limit. At least one vector tile is larger than ${process.env.BRIDGE_MAX_VTILE_BYTES_COMPRESSED/1000000}MB.`;

--- a/test/executable.test.js
+++ b/test/executable.test.js
@@ -325,3 +325,13 @@ test('layerName', function(t) {
     });
   });
 });
+
+test('size limit environment variable', function(t) {
+  var dst = dsturi('valid.mini.geojson');
+  var fixture = path.resolve(__dirname, 'fixtures', 'valid.mini.geojson');
+  var cmd = [ 'BRIDGE_MAX_VTILE_BYTES_COMPRESSED=10', copy, fixture, dst ].join(' ');
+  exec(cmd, function(err, stdout, stderr) {
+    t.ok(stderr.indexOf('Tile size exceeds limit. At least one vector tile is larger than') > -1, 'expected error');
+    t.end();
+  });
+});


### PR DESCRIPTION
This adds a nice error message to mapbox-tile-copy if the tilelive-bridge size limit environment variable is used.

cc @GretaCB @millzpaugh @springmeyer 