### PR TITLE
Update to latest s3urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@mapbox/mapbox-file-sniff": "~1.0.0",
     "@mapbox/mbtiles": "~0.9.0",
-    "@mapbox/s3urls": "^1.3.0",
+    "@mapbox/s3urls": "^1.5.3",
     "@mapbox/tilejson": "^1.0.1",
     "@mapbox/tilelive-omnivore": "~4.0.0",
     "@mapbox/tilelive": "~5.12.2",


### PR DESCRIPTION
- Fixes for bucket names with a `.` in them

Closes: https://github.com/mapbox/mapbox-tile-copy/issues/53