### PR TITLE
MBTiles validation bypass option

### DIFF
--- a/bin/mapbox-tile-copy.js
+++ b/bin/mapbox-tile-copy.js
@@ -65,6 +65,7 @@ if (isNumeric(argv.part) && isNumeric(argv.parts)) options.job = {
 if (isNumeric(argv.retry)) options.retry = parseInt(argv.retry, 10);
 if (isNumeric(argv.timeout)) options.timeout = parseInt(argv.timeout, 10);
 if (argv.bundle === 'true') options.bundle = true;
+if (argv.experiment) options.experiment = true;
 
 if (!dsturi) {
   console.error('You must provide a valid s3:// or file:// url');

--- a/bin/mapbox-tile-copy.js
+++ b/bin/mapbox-tile-copy.js
@@ -65,7 +65,7 @@ if (isNumeric(argv.part) && isNumeric(argv.parts)) options.job = {
 if (isNumeric(argv.retry)) options.retry = parseInt(argv.retry, 10);
 if (isNumeric(argv.timeout)) options.timeout = parseInt(argv.timeout, 10);
 if (argv.bundle === 'true') options.bundle = true;
-if (argv.experiment) options.experiment = true;
+if (argv['bypass-validation'] === 'true') options.bypassValidation = true;
 
 if (!dsturi) {
   console.error('You must provide a valid s3:// or file:// url');

--- a/lib/migration-stream.js
+++ b/lib/migration-stream.js
@@ -60,7 +60,7 @@ function MigrationStream() {
           data['mapnikVectorTile'] = error ? error.message : '';
 
           if (process.env.LOG_INVALID_VT){
-            fs.writeFileSync(os.tmpDir() + '/vt-invalid.json', JSON.stringify(data));
+            fs.writeFileSync(os.tmpdir() + '/vt-invalid.json', JSON.stringify(data));
           }
 
           if (error){
@@ -75,7 +75,7 @@ function MigrationStream() {
       });
     } else {
       if (!v1TileDataLogged && process.env.LOG_V1_TILES) {
-        fs.writeFileSync(os.tmpDir() + '/v1-stats.json', JSON.stringify({ 'tileVersion': '1' }));
+        fs.writeFileSync(os.tmpdir() + '/v1-stats.json', JSON.stringify({ 'tileVersion': '1' }));
         v1TileDataLogged = true;
       };
 

--- a/lib/migration-stream.js
+++ b/lib/migration-stream.js
@@ -63,7 +63,7 @@ function MigrationStream() {
             fs.writeFileSync(os.tmpdir() + '/vt-invalid.json', JSON.stringify(data));
           }
 
-          if (error){
+          if (error) {
             error.code = 'EINVALID';
             return callback(error);
           }

--- a/lib/tilelivecopy.js
+++ b/lib/tilelivecopy.js
@@ -9,6 +9,7 @@ var MigrationStream = require('./migration-stream');
 function tilelivecopy(srcUri, s3url, options, callback) {
   var scheme = 'scanline';
   var protocol = url.parse(srcUri).protocol;
+  var experimentalBypass = options.experiment || false; // bypass the MBTiles migration stream with "false"
   if (protocol === 'mbtiles:') scheme = 'list';
   if (protocol === 'omnivore:') scheme = 'scanline';
   options.type = scheme;
@@ -70,7 +71,7 @@ function tilelivecopy(srcUri, s3url, options, callback) {
         var transforms = [];
 
         if (options.stats) transforms.push(stats);
-        if (protocol === 'mbtiles:' || protocol === 'tilejson:') transforms.push(MigrationStream());
+        if ((protocol === 'mbtiles:' || protocol === 'tilejson:') && !experimentalBypass) transforms.push(MigrationStream());
         if (transforms.length > 0) options.transform = combiner(transforms);
 
         if (!dst.sse) dst.sse = 'AES256';

--- a/lib/tilelivecopy.js
+++ b/lib/tilelivecopy.js
@@ -71,7 +71,7 @@ function tilelivecopy(srcUri, s3url, options, callback) {
         var transforms = [];
 
         if (options.stats) transforms.push(stats);
-        if ((protocol === 'mbtiles:' || protocol === 'tilejson:') && !experimentalBypass) transforms.push(MigrationStream());
+        if ((protocol === 'mbtiles:' || protocol === 'tilejson:') && !bypassValidation) transforms.push(MigrationStream());
         if (transforms.length > 0) options.transform = combiner(transforms);
 
         if (!dst.sse) dst.sse = 'AES256';

--- a/lib/tilelivecopy.js
+++ b/lib/tilelivecopy.js
@@ -9,7 +9,7 @@ var MigrationStream = require('./migration-stream');
 function tilelivecopy(srcUri, s3url, options, callback) {
   var scheme = 'scanline';
   var protocol = url.parse(srcUri).protocol;
-  var experimentalBypass = options.experiment || false; // bypass the MBTiles migration stream with "false"
+  var bypass = options.bypassValidation || false; // bypass the MBTiles migration stream with "false"
   if (protocol === 'mbtiles:') scheme = 'list';
   if (protocol === 'omnivore:') scheme = 'scanline';
   options.type = scheme;
@@ -71,7 +71,7 @@ function tilelivecopy(srcUri, s3url, options, callback) {
         var transforms = [];
 
         if (options.stats) transforms.push(stats);
-        if ((protocol === 'mbtiles:' || protocol === 'tilejson:') && !bypassValidation) transforms.push(MigrationStream());
+        if ((protocol === 'mbtiles:' || protocol === 'tilejson:') && !bypass) transforms.push(MigrationStream());
         if (transforms.length > 0) options.transform = combiner(transforms);
 
         if (!dst.sse) dst.sse = 'AES256';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-tile-copy",
-  "version": "7.2.0",
+  "version": "7.3.0-1",
   "description": "From geodata files to tiles on S3",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-tile-copy",
-  "version": "7.3.0-1",
+  "version": "7.3.0-2",
   "description": "From geodata files to tiles on S3",
   "main": "index.js",
   "scripts": {

--- a/test/copy.tilelive.test.js
+++ b/test/copy.tilelive.test.js
@@ -145,6 +145,22 @@ test('copy mbtiles without v1 tile logging', function(t) {
   });
 });
 
+test.only('copy invalid mbtiles with bypassValidation option', function(t) {
+  process.env.LOG_INVALID_VT = true;
+  var fixture = path.resolve(__dirname, 'fixtures', 'v2-throw.mbtiles');
+  var src = 'mbtiles://' + fixture;
+  var dst = dsturi('v2-throw.mbtiles');
+
+  tileliveCopy(src, dst, { bypassValidation: true }, function(err) {
+    t.ifError(err);
+    tileCount(dst, function(err, count) {
+      t.ifError(err);
+      t.equal(count, 341, 'expected number of tiles');
+      t.end();
+    });
+  });
+});
+
 test('copy retry', function(t) {
   var fixture = path.resolve(__dirname, 'fixtures', 'valid.mbtiles');
   var src = 'mbtiles://' + fixture;

--- a/test/copy.tilelive.test.js
+++ b/test/copy.tilelive.test.js
@@ -145,7 +145,7 @@ test('copy mbtiles without v1 tile logging', function(t) {
   });
 });
 
-test.only('copy invalid mbtiles with bypassValidation option', function(t) {
+test('copy invalid mbtiles with bypassValidation option', function(t) {
   process.env.LOG_INVALID_VT = true;
   var fixture = path.resolve(__dirname, 'fixtures', 'v2-throw.mbtiles');
   var src = 'mbtiles://' + fixture;


### PR DESCRIPTION
This adds a `--bypass-validation` option to the CLI and JS interface to avoid the MBTiles migration stream & validation code paths.

cc @mapbox/maps-api 