### PR TITLE
fix spelling in help drive by

### DIFF
--- a/bin/help
+++ b/bin/help
@@ -15,4 +15,4 @@ Options:
   --stats=[filename]
   --retry=[number]     Retry get/put operations on failure
   --progressinterval=[number of seconds]   If not included, shows progress by default
-  --timeout=[numbel]   Timeout for copy operation, default=60000
+  --timeout=[number]   Timeout for copy operation, default=60000


### PR DESCRIPTION
noticed this while troubleshooting.  